### PR TITLE
Add `ajvOptions` to matcher interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Matchers included
 
-### `toMatchSchema(schema)`
+### `toMatchSchema(schema, [ajvOptions])`
 
 Validates that an object matches the given [JSON schema](http://json-schema.org/)
 
@@ -24,6 +24,22 @@ it('validates my json', () => {
 });
 ```
 
+### `toBeValidSchema([ajvOptions])`
+
+Validates that a schema is valid
+
+```js
+it('validates my schema', () => {
+  const schema = {
+    properties: {
+      hello: { type: 'string' },
+    },
+    required: ['hello'],
+  };
+  expect(schema).toBeValidSchema();
+});
+```
+
 ## Installation
 
 ```bash
@@ -35,25 +51,35 @@ $ npm install --save-dev jest-json-schema
 In any test file:
 
 ```js
-import { matchers } from 'jest-json-schema';
+import matchers from 'jest-json-schema';
 expect.extend(matchers);
 ```
 
 Or if you want it available for all test files then set it up the same way in a
 [test framework script file](http://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string)
 
-You can pass [Ajv options](http://epoberezkin.github.io/ajv/#options) using
-`matchersWithOptions` and passing it your options object. The only option passed
-by default is `allErrors: true`.
+You can pass [Ajv options](http://epoberezkin.github.io/ajv/#options) as a
+second parameter to any of the matchers. The only option passed by default is
+`allErrors: true`.
 
 ```js
-import { matchersWithOptions } from 'jest-json-schema';
+const ajvOptions = {
+  formats: {
+    bcp47: /^[a-z]{2}-[A-Z]{2}$/,
+  },
+};
 
-const formats = {
-  bcp47: /^[a-z]{2}-[A-Z]{2}$/,
-}
+const schema = {
+  type: 'object',
+  properties: {
+    lang: {
+      type: 'string',
+      format: 'bcp47',
+    },
+  },
+};
 
-expect.extend(matchersWithOptions({ formats }));
+expect({ lang: 'en-US' }).toMatchSchema(schema, ajvOptions);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ $ npm install --save-dev jest-json-schema
 In any test file:
 
 ```js
-import matchers from 'jest-json-schema';
-expect.extend(matchers);
+import 'jest-json-schema';
 ```
 
 Or if you want it available for all test files then set it up the same way in a

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -2,10 +2,6 @@
 
 exports[`index should export all the matchers from the matchers directory 1`] = `
 Object {
-  "matchers": Object {
-    "toBeValidSchema": [Function],
-    "toMatchSchema": [Function],
-  },
   "toBeValidSchema": [Function],
   "toMatchSchema": [Function],
 }

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index matchersWithOptions should return all the matchers 1`] = `
-Object {
-  "toBeValidSchema": [Function],
-  "toMatchSchema": [Function],
-}
-`;
-
 exports[`index should export all the matchers from the matchers directory 1`] = `
 Object {
   "toBeValidSchema": [Function],

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index matchersWithFormats should return all the matchers 1`] = `
-Object {
-  "toBeValidSchema": [Function],
-  "toMatchSchema": [Function],
-}
-`;
-
 exports[`index matchersWithOptions should return all the matchers 1`] = `
 Object {
   "toBeValidSchema": [Function],

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -2,6 +2,10 @@
 
 exports[`index should export all the matchers from the matchers directory 1`] = `
 Object {
+  "matchers": Object {
+    "toBeValidSchema": [Function],
+    "toMatchSchema": [Function],
+  },
   "toBeValidSchema": [Function],
   "toMatchSchema": [Function],
 }

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,7 +12,7 @@
  * the License.
  */
 
-const { matchers } = require('../index.js');
+const matchers = require('../index.js');
 
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,26 +12,11 @@
  * the License.
  */
 
-const { matchers, matchersWithFormats, matchersWithOptions } = require('../index.js');
+const { matchers, matchersWithOptions } = require('../index.js');
 
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {
     expect(matchers).toMatchSnapshot();
-  });
-
-  describe('matchersWithFormats', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn');
-
-    beforeEach(() => consoleWarnSpy.mockClear());
-
-    it('should return all the matchers', () => {
-      expect(matchersWithFormats()).toMatchSnapshot();
-    });
-
-    it('should warn that the method is deprecated', () => {
-      matchersWithFormats();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-    });
   });
 
   describe('matchersWithOptions', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,16 +12,10 @@
  * the License.
  */
 
-const { matchers, matchersWithOptions } = require('../index.js');
+const { matchers } = require('../index.js');
 
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {
     expect(matchers).toMatchSnapshot();
-  });
-
-  describe('matchersWithOptions', () => {
-    it('should return all the matchers', () => {
-      expect(matchersWithOptions()).toMatchSnapshot();
-    });
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,10 +12,17 @@
  * the License.
  */
 
-const matchers = require('../index.js');
-
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {
-    expect(matchers).toMatchSnapshot();
+    expect(require('../index.js')).toMatchSnapshot();
+  });
+
+  it('should extend jest expect if it is available on the global object', () => {
+    const extend = jest.spyOn(global.expect, 'extend');
+
+    jest.resetModules();
+    const matchers = require('../index.js');
+
+    expect(extend).toHaveBeenCalledWith(matchers);
   });
 });

--- a/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
@@ -85,11 +85,3 @@ received
   .hello should match pattern \\"[a-z]+\\"
 "
 `;
-
-exports[`toMatchSchema includes the description in the error when provided 1`] = `
-"expect(received).toMatchSchema(schema)
-
-en-US language pack
-  .hello should be string
-"
-`;

--- a/__tests__/matchers/toBeValidSchema.spec.js
+++ b/__tests__/matchers/toBeValidSchema.spec.js
@@ -13,7 +13,7 @@
  */
 
 const chalk = require('chalk');
-const toBeValidSchemaUnderTest = require('../../index').matchers.toBeValidSchema;
+const toBeValidSchemaUnderTest = require('../../index').toBeValidSchema;
 
 chalk.enabled = false;
 

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -14,17 +14,11 @@
 
 const chalk = require('chalk');
 const toMatchSchemaUnderTest = require('../../index').matchers.toMatchSchema;
-const toMatchSchemaWithFormatsUnderTest = require('../../index').matchersWithOptions({
-  formats: {
-    bcp47: /^[a-z]{2}-[A-Z]{2}$/,
-  },
-}).toMatchSchema;
 
 chalk.enabled = false;
 
 expect.extend({
   toMatchSchemaUnderTest,
-  toMatchSchemaWithFormatsUnderTest,
 });
 
 describe('toMatchSchema', () => {
@@ -104,6 +98,8 @@ describe('toMatchSchema', () => {
 
   describe('custom formats', () => {
     describe('bcp47', () => {
+      const ajvOptions = { formats: { bcp47: /^[a-z]{2}-[A-Z]{2}$/ } };
+
       beforeEach(() => {
         schema = {
           properties: {
@@ -118,7 +114,7 @@ describe('toMatchSchema', () => {
         'xx-XX',
       ].forEach((locale) => {
         it(`it matches ${locale}`, () => {
-          expect({ locale }).toMatchSchemaWithFormatsUnderTest(schema);
+          expect({ locale }).toMatchSchemaUnderTest(schema, ajvOptions);
         });
       });
 
@@ -130,7 +126,7 @@ describe('toMatchSchema', () => {
         '123',
       ].forEach((locale) => {
         it(`it does not match ${locale}`, () => {
-          expect(() => expect({ locale }).toMatchSchemaWithFormatsUnderTest(schema))
+          expect(() => expect({ locale }).toMatchSchemaUnderTest(schema, ajvOptions))
             .toThrowErrorMatchingSnapshot();
         });
       });

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -13,7 +13,7 @@
  */
 
 const chalk = require('chalk');
-const toMatchSchemaUnderTest = require('../../index').matchers.toMatchSchema;
+const toMatchSchemaUnderTest = require('../../index').toMatchSchema;
 
 chalk.enabled = false;
 

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -14,8 +14,10 @@
 
 const chalk = require('chalk');
 const toMatchSchemaUnderTest = require('../../index').matchers.toMatchSchema;
-const toMatchSchemaWithFormatsUnderTest = require('../../index').matchersWithFormats({
-  bcp47: /^[a-z]{2}-[A-Z]{2}$/,
+const toMatchSchemaWithFormatsUnderTest = require('../../index').matchersWithOptions({
+  formats: {
+    bcp47: /^[a-z]{2}-[A-Z]{2}$/,
+  },
 }).toMatchSchema;
 
 chalk.enabled = false;

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -72,12 +72,6 @@ describe('toMatchSchema', () => {
       .toThrowErrorMatchingSnapshot();
   });
 
-  it('includes the description in the error when provided', () => {
-    const testObj = { hello: 1 };
-    expect(() => expect(testObj).toMatchSchemaUnderTest(schema, 'en-US language pack'))
-      .toThrowErrorMatchingSnapshot();
-  });
-
   it('fails for matching schema when using .not', () => {
     const testObj = { hello: 'world' };
     expect(() => expect(testObj).not.toMatchSchemaUnderTest(schema))

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@
  */
 
 const merge = require('lodash/merge');
-const chalk = require('chalk');
 const buildToMatchSchema = require('./matchers/toMatchSchema');
 const buildToBeValidSchema = require('./matchers/toBeValidSchema');
 
@@ -31,11 +30,4 @@ function matchersWithOptions(userOptions = {}) {
 }
 
 module.exports.matchers = matchersWithOptions();
-module.exports.matchersWithFormats = (formats = {}) => {
-  console.warn(chalk.yellow(
-    'matchersWithFormats has been deprecated and will be removed in the next major version.\n' +
-    'Please use matchersWithOptions instead.'
-  ));
-  return matchersWithOptions({ unknownFormats: true, formats });
-};
 module.exports.matchersWithOptions = matchersWithOptions;

--- a/index.js
+++ b/index.js
@@ -18,8 +18,4 @@ const toBeValidSchema = require('./matchers/toBeValidSchema');
 module.exports = {
   toMatchSchema,
   toBeValidSchema,
-  matchers: {
-    toMatchSchema,
-    toBeValidSchema,
-  },
 };

--- a/index.js
+++ b/index.js
@@ -15,12 +15,7 @@
 const toMatchSchema = require('./matchers/toMatchSchema');
 const toBeValidSchema = require('./matchers/toBeValidSchema');
 
-function matchersWithOptions(userOptions = {}) {
-  return {
-    toMatchSchema: (received, schema) => toMatchSchema(received, schema, userOptions),
-    toBeValidSchema: received => toBeValidSchema(received, userOptions),
-  };
-}
-
-module.exports.matchers = matchersWithOptions();
-module.exports.matchersWithOptions = matchersWithOptions;
+module.exports.matchers = {
+  toMatchSchema,
+  toBeValidSchema,
+};

--- a/index.js
+++ b/index.js
@@ -15,14 +15,16 @@
 const toMatchSchema = require('./matchers/toMatchSchema');
 const toBeValidSchema = require('./matchers/toBeValidSchema');
 
+const { expect } = global;
+
 const matchers = {
   toMatchSchema,
   toBeValidSchema,
 };
 
-const jestExpect = global.expect;
-if (jestExpect !== undefined) {
-  jestExpect.extend(matchers);
+/* istanbul ignore next */
+if (expect !== undefined) {
+  expect.extend(matchers);
 }
 
 module.exports = matchers;

--- a/index.js
+++ b/index.js
@@ -12,20 +12,13 @@
  * the License.
  */
 
-const merge = require('lodash/merge');
-const buildToMatchSchema = require('./matchers/toMatchSchema');
-const buildToBeValidSchema = require('./matchers/toBeValidSchema');
+const toMatchSchema = require('./matchers/toMatchSchema');
+const toBeValidSchema = require('./matchers/toBeValidSchema');
 
 function matchersWithOptions(userOptions = {}) {
-  const defaultOptions = {
-    allErrors: true,
-  };
-
-  const options = merge(defaultOptions, userOptions);
-
   return {
-    toMatchSchema: buildToMatchSchema(options),
-    toBeValidSchema: buildToBeValidSchema(options),
+    toMatchSchema: (received, schema) => toMatchSchema(received, schema, userOptions),
+    toBeValidSchema: received => toBeValidSchema(received, userOptions),
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,14 @@
 const toMatchSchema = require('./matchers/toMatchSchema');
 const toBeValidSchema = require('./matchers/toBeValidSchema');
 
-module.exports = {
+const matchers = {
   toMatchSchema,
   toBeValidSchema,
 };
+
+const jestExpect = global.expect;
+if (jestExpect !== undefined) {
+  jestExpect.extend(matchers);
+}
+
+module.exports = matchers;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@
 const toMatchSchema = require('./matchers/toMatchSchema');
 const toBeValidSchema = require('./matchers/toBeValidSchema');
 
-module.exports.matchers = {
+module.exports = {
   toMatchSchema,
   toBeValidSchema,
+  matchers: {
+    toMatchSchema,
+    toBeValidSchema,
+  },
 };

--- a/matchers/toBeValidSchema.js
+++ b/matchers/toBeValidSchema.js
@@ -14,37 +14,36 @@
 
 const Ajv = require('ajv');
 const chalk = require('chalk');
+const merge = require('lodash/merge');
 const { matcherHint } = require('jest-matcher-utils');
 
-function buildToBeValidSchema(ajvOptions) {
-  return function toBeValidSchema(received) {
-    const ajv = new Ajv(ajvOptions);
+function toBeValidSchema(received, ajvOptions) {
+  const ajv = new Ajv(merge({ allErrors: true }, ajvOptions));
 
-    const pass = ajv.validateSchema(received);
+  const pass = ajv.validateSchema(received);
 
-    const message = pass
-      ? () => `${matcherHint('.not.toBeValidSchema', 'received', '')}\n\nExpected input not to be a valid JSON schema`
-      : () => {
-        let messageToPrint = 'schema\n';
-        ajv.errors.forEach((error) => {
-          let line = error.message;
+  const message = pass
+    ? () => `${matcherHint('.not.toBeValidSchema', 'received', '')}\n\nExpected input not to be a valid JSON schema`
+    : () => {
+      let messageToPrint = 'schema\n';
+      ajv.errors.forEach((error) => {
+        let line = error.message;
 
-          if (error.dataPath) {
-            line = `${error.dataPath} ${error.message}`;
-          }
+        if (error.dataPath) {
+          line = `${error.dataPath} ${error.message}`;
+        }
 
-          messageToPrint += chalk.red(`  ${line}\n`);
-        });
-        return `${matcherHint('.toBeValidSchema', 'schema', '')}\n\n${messageToPrint}`;
-      };
-
-    return {
-      actual: received,
-      message,
-      name: 'toBeValidSchema',
-      pass,
+        messageToPrint += chalk.red(`  ${line}\n`);
+      });
+      return `${matcherHint('.toBeValidSchema', 'schema', '')}\n\n${messageToPrint}`;
     };
+
+  return {
+    actual: received,
+    message,
+    name: 'toBeValidSchema',
+    pass,
   };
 }
 
-module.exports = buildToBeValidSchema;
+module.exports = toBeValidSchema;

--- a/matchers/toMatchSchema.js
+++ b/matchers/toMatchSchema.js
@@ -14,39 +14,38 @@
 
 const Ajv = require('ajv');
 const chalk = require('chalk');
+const merge = require('lodash/merge');
 const { matcherHint } = require('jest-matcher-utils');
 
-function buildToMatchSchema(ajvOptions) {
-  return function toMatchSchema(received, schema) {
-    const ajv = new Ajv(ajvOptions);
-    const validate = ajv.compile(schema);
-    const pass = validate(received);
+function toMatchSchema(received, schema, ajvOptions) {
+  const ajv = new Ajv(merge({ allErrors: true }, ajvOptions));
+  const validate = ajv.compile(schema);
+  const pass = validate(received);
 
-    const message = pass
-      ? () => `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema`
-      : () => {
-        let messageToPrint = 'received\n';
-        validate.errors.forEach((error) => {
-          let line = error.message;
+  const message = pass
+    ? () => `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema`
+    : () => {
+      let messageToPrint = 'received\n';
+      validate.errors.forEach((error) => {
+        let line = error.message;
 
-          if (error.keyword === 'additionalProperties') {
-            line = `${error.message}, but found '${error.params.additionalProperty}'`;
-          } else if (error.dataPath) {
-            line = `${error.dataPath} ${error.message}`;
-          }
+        if (error.keyword === 'additionalProperties') {
+          line = `${error.message}, but found '${error.params.additionalProperty}'`;
+        } else if (error.dataPath) {
+          line = `${error.dataPath} ${error.message}`;
+        }
 
-          messageToPrint += chalk.red(`  ${line}\n`);
-        });
-        return `${matcherHint('.toMatchSchema', undefined, 'schema')}\n\n${messageToPrint}`;
-      };
-
-    return {
-      actual: received,
-      message,
-      name: 'toMatchSchema',
-      pass,
+        messageToPrint += chalk.red(`  ${line}\n`);
+      });
+      return `${matcherHint('.toMatchSchema', undefined, 'schema')}\n\n${messageToPrint}`;
     };
+
+  return {
+    actual: received,
+    message,
+    name: 'toMatchSchema',
+    pass,
   };
 }
 
-module.exports = buildToMatchSchema;
+module.exports = toMatchSchema;

--- a/matchers/toMatchSchema.js
+++ b/matchers/toMatchSchema.js
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const { matcherHint } = require('jest-matcher-utils');
 
 function buildToMatchSchema(ajvOptions) {
-  return function toMatchSchema(received, schema, description) {
+  return function toMatchSchema(received, schema) {
     const ajv = new Ajv(ajvOptions);
     const validate = ajv.compile(schema);
     const pass = validate(received);
@@ -25,7 +25,7 @@ function buildToMatchSchema(ajvOptions) {
     const message = pass
       ? () => `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema`
       : () => {
-        let messageToPrint = `${description || 'received'}\n`;
+        let messageToPrint = 'received\n';
         validate.errors.forEach((error) => {
           let line = error.message;
 


### PR DESCRIPTION
Hi, I really like your jest-json matchers – thanks for creating them!

I've found it great up until the point where my schemas grow large and I split them into multiple files, requiring me to use `matchersWithOptions`.

I initially wrapped the library to allow me to pass `ajvOptions` as a second parameter to the matchers (removing `description` from the matcher interface) and the developer ergonomics felt good enough to push upstream.

I hope that the changes to the API are helpful to others too.