### PR TITLE
Update dependencies incl. Jest to version 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "10"
   - "8"
   - "6"

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,7 +12,7 @@
  * the License.
  */
 
-const { matchers, matchersWithFormats, matchersWithOptions } = require('../index.js');
+const { matchers, matchersWithFormats, matchersWithOptions } = require('..');
 
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {

--- a/__tests__/matchers/toBeValidSchema.spec.js
+++ b/__tests__/matchers/toBeValidSchema.spec.js
@@ -13,7 +13,7 @@
  */
 
 const chalk = require('chalk');
-const toBeValidSchemaUnderTest = require('../../index').matchers.toBeValidSchema;
+const toBeValidSchemaUnderTest = require('../..').matchers.toBeValidSchema;
 
 chalk.enabled = false;
 

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -13,8 +13,8 @@
  */
 
 const chalk = require('chalk');
-const toMatchSchemaUnderTest = require('../../index').matchers.toMatchSchema;
-const toMatchSchemaWithFormatsUnderTest = require('../../index').matchersWithFormats({
+const toMatchSchemaUnderTest = require('../..').matchers.toMatchSchema;
+const toMatchSchemaWithFormatsUnderTest = require('../..').matchersWithFormats({
   bcp47: /^[a-z]{2}-[A-Z]{2}$/,
 }).toMatchSchema;
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function matchersWithOptions(userOptions = {}) {
 module.exports.matchers = matchersWithOptions();
 module.exports.matchersWithFormats = (formats = {}) => {
   console.warn(chalk.yellow(
-    'matchersWithFormats has been deprecated and will be removed in the next major version.\n' +
-    'Please use matchersWithOptions instead.'
+    'matchersWithFormats has been deprecated and will be removed in the next major version.\n'
+    + 'Please use matchersWithOptions instead.'
   ));
   return matchersWithOptions({ unknownFormats: true, formats });
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "amex-jest-preset": "^5.0.0",
     "eslint": "^5.2.0",
     "eslint-config-amex": "^7.1.1",
-    "jest": "^23.4.2"
+    "jest": "^24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "eslint": "^5.2.0",
     "eslint-config-amex": "^9.0.0",
     "jest": "^24.0.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "amex-jest-preset": "^5.0.0",
     "eslint": "^5.2.0",
-    "eslint-config-amex": "^7.1.1",
+    "eslint-config-amex": "^9.0.0",
     "jest": "^24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ajv": "^6.5.2",
     "chalk": "^2.4.1",
-    "jest-matcher-utils": "^23.2.0",
+    "jest-matcher-utils": "^24.0.0",
     "lodash": "^4.17.10"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm mainly after this for the update to jest-matcher-utils@24 for deduplication with jest itself.