### PR TITLE
add jest expect.extend() support

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,3 +38,5 @@ module.exports.matchersWithFormats = (formats = {}) => {
   return matchersWithOptions({ unknownFormats: true, formats });
 };
 module.exports.matchersWithOptions = matchersWithOptions;
+
+expect.extend(module.exports.matchers);


### PR DESCRIPTION
add support for _jest_ `expect` support to make _matchers_ publically available to all test files.

Hi!
after installing and following [Usage](https://github.com/americanexpress/jest-json-schema#usage) guide and tried to make matcher available across all test files, i noticed that provided link in the description [here](http://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string) has been changed and redirects to an unknown place! i followed official Jest documentation and the closest configuration option provided currently (AFAIK) was [setupFilesAfterEnv](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array). i added a module resolver to 'jest-json-schema' by adding `require.resolve('jest-json-schema')` statement to `setupFilesAfterEnv` array, but once i ran tests, it throws `TypeError: expect(...).toMatchSchema is not a function` error message and after waisting sometime trying to find out the reason, i noticed that Jest custom matchers MUST be added using `expect.extend(matcher)` function.
im not good at Jest its Matcher, but i think it is the manner of _versions_!
i currently added a custom `setup.js` containing following code:
```js
const { matchers } = require('jest-json-schema');
expect.extend(matchers);
```
referencing this file instead of 'jest-json-schema' in `setupFilesAfterEnv` array makes it working! but i think making this matcher publically available to all test scripts is useful and does not make any problem like naming collision or anything else.
im also using Jest(v24.5.0), NodeJS (v11.1.0).

Thank you!