### PR TITLE
Output more detail when ajvOptions.verbose enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,51 @@ expect.extend(matchersWithOptions({ formats }, (ajv) => {
 
 Ajv supports a verbose option flag which enables more information about individual
 errors. This extra information can mean that we can output to Jest more meaningful
-errors that can help the development process.
+errors that can help the development process:
+
+```js
+const { matchersWithOptions } = require('jest-json-schema');
+
+expect.extend(matchersWithOptions({
+  verbose: true
+}));
+
+test('check that property errors are outputted', () => {
+  const schema = {
+    $id: 'testSchema',
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+      },
+      dob: {
+        type: 'string',
+        format: 'date',
+      },
+    },
+  };
+
+  const invalidData = {
+    name: null,
+    dob: '02-29-2000',
+  };
+
+  expect(() => {
+    expect(invalidData).toMatchSchema(schema)
+  }).toThrowErrorMatchingInlineSnapshot(`
+"expect(received).toMatchSchema(schema)
+
+Received:
+  .name should be string
+    Received: <null>
+    Path: testSchema#/properties/name/type
+  .dob should match format \\"date\\"
+    Received: <string> 02-29-2000
+    Path: testSchema#/properties/dob/format
+"
+`);
+});
+```
 
 ### Example using multiple schema files
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ expect.extend(matchersWithOptions({ formats }, (ajv) => {
 
 Ajv supports a verbose option flag which enables more information about individual
 errors. This extra information can mean that we can output to Jest more meaningful
-information about specific errors that can help the development process.
+errors that can help the development process.
 
 ### Example using multiple schema files
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ interface:
 #### schemaA.test.js
 
 ```js
-const { matchersWithOptions } = require("jest-json-schema");
+const { matchersWithOptions } = require('jest-json-schema');
 
 // Local schema files are imported like normal. If you use TypeScript you
 // will need to ensure `--resolveJsonModule` is enabled.
-const schemaA = require("./schemaA.json");
-const schemaB = require("./schemaB.json");
+const schemaA = require('./schemaA.json');
+const schemaB = require('./schemaB.json');
 
 expect.extend(matchersWithOptions({
   // Loading in a schema which is comprised only of definitions,
@@ -181,16 +181,16 @@ expect.extend(matchersWithOptions({
   schemas: [schemaA]
 });
 
-test("schemaA is valid", () => {
+test('schemaA is valid', () => {
   expect(schemaA).toBeValidSchema();
 });
 
-test("using schemaA to build a test schema to test a specific definition", () => {
+test('using schemaA to build a test schema to test a specific definition', () => {
   // This is a test schema which references a definition in one of the
   // pre-loaded schemas. This can allow us to write tests for specific
   // definitions.
   const testSchema = {
-    $ref: "schemaA#/definitions/testA"
+    $ref: 'schemaA#/definitions/testA'
   };
 
   expect(testSchema).toBeValidSchema();
@@ -201,21 +201,21 @@ test("using schemaA to build a test schema to test a specific definition", () =>
   // This example runs through a number of values that we know don't match
   // the schema, ensuring that any future changes to the schema will require
   // the test to be updated.
-  ["1", true, false, null, [], {}].forEach(value => {
+  ['1', true, false, null, [], {}].forEach(value => {
      expect(value).not.toMatchSchema(testSchema);
   });
 });
 
-test("using schemaB which already references a definition in schemaA", () => {
+test('using schemaB which already references a definition in schemaA', () => {
   expect(schemaB).toBeValidSchema();
 
   // Valid
-  ["", "1", null].forEach(value => {
+  ['', '1', null].forEach(value => {
     expect(value).toMatchSchema(schemaB);
   });
 
   // Invalid
-  ["1", true, false, [], {}].forEach(value => {
+  ['1', true, false, [], {}].forEach(value => {
      expect(value).not.toMatchSchema(schemaB);
   });
 });

--- a/README.md
+++ b/README.md
@@ -77,7 +77,108 @@ expect.extend(matchersWithOptions({ formats }, (ajv) => {
 }));
 ```
 
+### Verbose errors
+
+Ajv supports a verbose option flag which enables more information about individual
+errors. This extra information can mean that we can output to Jest more meaningful
+information about specific errors that can help the development process.
+
+### Example using multiple schema files
+
+If you organise your schemas into separate files and use refs which point to the
+various different schemas, it will be important to include those dependent
+schema files when extending Jest's `expect` handler, using the `matchersWithOptions`
+interface:
+
+#### schemaA.json
+
+```json
+{
+  "$id": "schemaA",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Example of a definition schema.",
+  "definitions": {
+    "testA": {
+      "type": "number",
+      "const": 1
+    },
+    "testB": {
+      "type": ["null", "string"]
+    }
+  }
+}
+```
+
+#### schemaB.json
+
+```json
+{
+  "$id": "schemaB",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Example of a schema that references another schema.",
+  "$ref": "schemaA#/definitions/testB"
+}
+```
+
+#### schemaA.test.js
+
+```js
+const { matchersWithOptions } = require("jest-json-schema");
+
+// Local schema files are imported like normal. If you use TypeScript you
+// will need to ensure `--resolveJsonModule` is enabled.
+const schemaA = require("./schemaA.json");
+const schemaB = require("./schemaB.json");
+
+expect.extend(matchersWithOptions({
+  // Loading in a schema which is comprised only of definitions,
+  // which means specific test schemas need to be created.
+  // This is good for testing specific conditions for definition schemas.
+  schemas: [schemaA]
+});
+
+test("schemaA is valid", () => {
+  expect(schemaA).toBeValidSchema();
+});
+
+test("using schemaA to build a test schema to test a specific definition", () => {
+  // This is a test schema which references a definition in one of the
+  // pre-loaded schemas. This can allow us to write tests for specific
+  // definitions.
+  const testSchema = {
+    $ref: "schemaA#/definitions/testA"
+  };
+
+  expect(testSchema).toBeValidSchema();
+
+  // Valid
+  expect(1).toMatchSchema(testSchema);
+
+  // This example runs through a number of values that we know don't match
+  // the schema, ensuring that any future changes to the schema will require
+  // the test to be updated.
+  ["1", true, false, null, [], {}].forEach(value => {
+     expect(value).not.toMatchSchema(testSchema);
+  });
+});
+
+test("using schemaB which already references a definition in schemaA", () => {
+  expect(schemaB).toBeValidSchema();
+
+  // Valid
+  ["", "1", null].forEach(value => {
+    expect(value).toMatchSchema(schemaB);
+  });
+
+  // Invalid
+  ["1", true, false, [], {}].forEach(value => {
+     expect(value).not.toMatchSchema(schemaB);
+  });
+});
+```
+
 ## Contributing
+
 We welcome Your interest in the American Express Open Source Community on Github.
 Any Contributor to any Open Source Project managed by the American Express Open
 Source Community must accept and sign an Agreement indicating agreement to the
@@ -87,9 +188,11 @@ right, title, and interest, if any, in and to Your Contributions. Please [fill
 out the Agreement](https://cla-assistant.io/americanexpress/).
 
 ## License
+
 Any contributions made under this project will be governed by the [Apache License
  2.0](https://github.com/americanexpress/jest-json-schema/blob/master/LICENSE.txt).
 
 ## Code of Conduct
+
 This project adheres to the [American Express Community Guidelines](https://github.com/americanexpress/jest-json-schema/wiki/Code-of-Conduct).
 By participating, you are expected to honor these guidelines.

--- a/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
@@ -116,13 +116,71 @@ en-US language pack
 "
 `;
 
-exports[`toMatchSchema output verbose errors should output an error with only the received input data printed 1`] = `
+exports[`toMatchSchema output verbose errors should display schema $id in the schema path 1`] = `
+"expect(received).toMatchSchema(schema)
+
+received
+  should be string
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 1`] = `
 "expect(received).not.toMatchSchema(schema)
 
 Expected value not to match schema
 
 received
-{\\"testType\\":\\"this is valid but expect().not.toMatchSchema has been used\\",\\"testEnum\\":1,\\"testConst\\":true}
+<null>
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 2`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+<boolean> true
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 3`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+<number> 1
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 4`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+<string> this is valid but expect().not.toMatchSchema has been used
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 5`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+<object> {}
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input printed 6`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+<array> [\\"this is valid but expect().not.toMatchSchema has been used\\"]
 "
 `;
 
@@ -131,132 +189,132 @@ exports[`toMatchSchema output verbose errors should output error with details pr
 
 received
   should NOT have more than 1 properties
-    Path:     testSchema#/allOf/0/maxProperties
+    Path:     #/allOf/0/maxProperties
   should NOT have fewer than 999 properties
-    Path:     testSchema#/allOf/0/minProperties
+    Path:     #/allOf/0/minProperties
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testType' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testNotEmpty' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testEnum' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testConst' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testFormat' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testPattern' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testItems' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testNumber' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testIf' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testElse' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   should match pattern \\"^false\\"
-    Path:     testSchema#/allOf/0/propertyNames/pattern
+    Path:     #/allOf/0/propertyNames/pattern
   property name 'testThen' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
-    Path:     testSchema#/allOf/0/propertyNames
+    Path:     #/allOf/0/propertyNames
   .testType should be null
     Received: <boolean> false
-    Path:     testSchema#/allOf/0/properties/testType/type
+    Path:     #/allOf/0/properties/testType/type
   .testNotEmpty should NOT be shorter than 1 characters
     Received: <empty string>
-    Path:     testSchema#/allOf/0/properties/testNotEmpty/minLength
+    Path:     #/allOf/0/properties/testNotEmpty/minLength
   .testEnum should be equal to one of the allowed values
     Expected: [1,2]
     Received: <boolean> false
-    Path:     testSchema#/allOf/0/properties/testEnum/enum
+    Path:     #/allOf/0/properties/testEnum/enum
   .testConst should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
-    Path:     testSchema#/allOf/0/properties/testConst/const
+    Path:     #/allOf/0/properties/testConst/const
   .testFormat should match format \\"email\\"
     Received: <string> test
-    Path:     testSchema#/allOf/0/properties/testFormat/format
+    Path:     #/allOf/0/properties/testFormat/format
   .testPattern should match pattern \\"[0-9]+\\"
     Received: <string> test
-    Path:     testSchema#/allOf/0/properties/testPattern/pattern
+    Path:     #/allOf/0/properties/testPattern/pattern
   .testItems should NOT have more than 1 items
     Received: <array> [false,1]
-    Path:     testSchema#/allOf/0/properties/testItems/maxItems
+    Path:     #/allOf/0/properties/testItems/maxItems
   .testItems should NOT have fewer than 5 items
     Received: <array> [false,1]
-    Path:     testSchema#/allOf/0/properties/testItems/minItems
+    Path:     #/allOf/0/properties/testItems/minItems
   .testItems[0] should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
-    Path:     testSchema#/allOf/0/properties/testItems/items/const
+    Path:     #/allOf/0/properties/testItems/items/const
   .testItems[1] should be equal to constant
     Expected: <boolean> true
     Received: <number> 1
-    Path:     testSchema#/allOf/0/properties/testItems/items/const
+    Path:     #/allOf/0/properties/testItems/items/const
   .testItems[0] should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
-    Path:     testSchema#/allOf/0/properties/testItems/contains/const
+    Path:     #/allOf/0/properties/testItems/contains/const
   .testItems[1] should be equal to constant
     Expected: <boolean> true
     Received: <number> 1
-    Path:     testSchema#/allOf/0/properties/testItems/contains/const
+    Path:     #/allOf/0/properties/testItems/contains/const
   .testItems should contain a valid item
     Expected: {\\"const\\":true}
     Received: <array> [false,1]
-    Path:     testSchema#/allOf/0/properties/testItems/contains
+    Path:     #/allOf/0/properties/testItems/contains
   .testNumber should be <= 0
     Received: <number> 1
-    Path:     testSchema#/allOf/0/properties/testNumber/maximum
+    Path:     #/allOf/0/properties/testNumber/maximum
   .testNumber should be > 999
     Received: <number> 1
-    Path:     testSchema#/allOf/0/properties/testNumber/exclusiveMinimum
+    Path:     #/allOf/0/properties/testNumber/exclusiveMinimum
   .testNumber should be multiple of 5
     Received: <number> 1
-    Path:     testSchema#/allOf/0/properties/testNumber/multipleOf
+    Path:     #/allOf/0/properties/testNumber/multipleOf
   should have required property 'testRequired'
-    Path:     testSchema#/allOf/0/required
+    Path:     #/allOf/0/required
   .testThen should be equal to constant
     Expected: <boolean> true
     Received: <null>
-    Path:     testSchema#/allOf/1/then/properties/testThen/const
+    Path:     #/allOf/1/then/properties/testThen/const
   should match \\"then\\" schema
     Expected: {\\"type\\":\\"object\\",\\"properties\\":{\\"testThen\\":{\\"const\\":true}}}
     Received: {\\"testType\\":false,\\"testNotEmpty\\":\\"\\",\\"testEnum\\":false,\\"testConst\\":false,\\"testFormat\\":\\"test\\",\\"testPattern\\":\\"test\\",\\"testItems\\":[false,1],\\"testNumber\\":1,\\"testIf\\":true,\\"testThen\\":null}
-    Path:     testSchema#/allOf/1/if
+    Path:     #/allOf/1/if
   should NOT be valid
     Expected: {\\"type\\":\\"object\\"}
     Received: {\\"testType\\":false,\\"testNotEmpty\\":\\"\\",\\"testEnum\\":false,\\"testConst\\":false,\\"testFormat\\":\\"test\\",\\"testPattern\\":\\"test\\",\\"testItems\\":[false,1],\\"testNumber\\":1,\\"testIf\\":true,\\"testThen\\":null}
-    Path:     testSchema#/allOf/2/not
+    Path:     #/allOf/2/not
 "
 `;

--- a/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
@@ -120,7 +120,9 @@ exports[`toMatchSchema output verbose errors should display schema $id in the sc
 "expect(received).toMatchSchema(schema)
 
 received
-  should be string
+  .test should be number
+    Received: <string> 123
+    Path:     testSchema#/allOf/0/properties/test/type
 "
 `;
 

--- a/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
@@ -45,6 +45,8 @@ exports[`toMatchSchema custom keywords instanceof 1`] = `
 
 received
   should pass \\"instanceof\\" keyword validation
+    Expected: <string> Array
+    Path:     #/instanceof
 "
 `;
 
@@ -53,6 +55,8 @@ exports[`toMatchSchema custom keywords typeof 1`] = `
 
 received
   should pass \\"typeof\\" keyword validation
+    Expected: <string> string
+    Path:     #/typeof
 "
 `;
 
@@ -67,7 +71,9 @@ received
 exports[`toMatchSchema fails for matching schema when using .not 1`] = `
 "expect(received).not.toMatchSchema(schema)
 
-Expected value not to match schema"
+Expected value not to match schema
+
+"
 `;
 
 exports[`toMatchSchema fails for missing required keys 1`] = `
@@ -107,5 +113,150 @@ exports[`toMatchSchema includes the description in the error when provided 1`] =
 
 en-US language pack
   .hello should be string
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output an error with only the received input data printed 1`] = `
+"expect(received).not.toMatchSchema(schema)
+
+Expected value not to match schema
+
+received
+{\\"testType\\":\\"this is valid but expect().not.toMatchSchema has been used\\",\\"testEnum\\":1,\\"testConst\\":true}
+"
+`;
+
+exports[`toMatchSchema output verbose errors should output error with details printed per errored property 1`] = `
+"expect(received).toMatchSchema(schema)
+
+received
+  should NOT have more than 1 properties
+    Path:     testSchema#/allOf/0/maxProperties
+  should NOT have fewer than 999 properties
+    Path:     testSchema#/allOf/0/minProperties
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testType' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testNotEmpty' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testEnum' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testConst' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testFormat' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testPattern' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testItems' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testNumber' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testIf' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testElse' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  should match pattern \\"^false\\"
+    Path:     testSchema#/allOf/0/propertyNames/pattern
+  property name 'testThen' is invalid
+    Expected: {\\"pattern\\":\\"^false\\"}
+    Path:     testSchema#/allOf/0/propertyNames
+  .testType should be null
+    Received: <boolean> false
+    Path:     testSchema#/allOf/0/properties/testType/type
+  .testNotEmpty should NOT be shorter than 1 characters
+    Received: <empty string>
+    Path:     testSchema#/allOf/0/properties/testNotEmpty/minLength
+  .testEnum should be equal to one of the allowed values
+    Expected: [1,2]
+    Received: <boolean> false
+    Path:     testSchema#/allOf/0/properties/testEnum/enum
+  .testConst should be equal to constant
+    Expected: <boolean> true
+    Received: <boolean> false
+    Path:     testSchema#/allOf/0/properties/testConst/const
+  .testFormat should match format \\"email\\"
+    Received: <string> test
+    Path:     testSchema#/allOf/0/properties/testFormat/format
+  .testPattern should match pattern \\"[0-9]+\\"
+    Received: <string> test
+    Path:     testSchema#/allOf/0/properties/testPattern/pattern
+  .testItems should NOT have more than 1 items
+    Received: <array> [false,1]
+    Path:     testSchema#/allOf/0/properties/testItems/maxItems
+  .testItems should NOT have fewer than 5 items
+    Received: <array> [false,1]
+    Path:     testSchema#/allOf/0/properties/testItems/minItems
+  .testItems[0] should be equal to constant
+    Expected: <boolean> true
+    Received: <boolean> false
+    Path:     testSchema#/allOf/0/properties/testItems/items/const
+  .testItems[1] should be equal to constant
+    Expected: <boolean> true
+    Received: <number> 1
+    Path:     testSchema#/allOf/0/properties/testItems/items/const
+  .testItems[0] should be equal to constant
+    Expected: <boolean> true
+    Received: <boolean> false
+    Path:     testSchema#/allOf/0/properties/testItems/contains/const
+  .testItems[1] should be equal to constant
+    Expected: <boolean> true
+    Received: <number> 1
+    Path:     testSchema#/allOf/0/properties/testItems/contains/const
+  .testItems should contain a valid item
+    Expected: {\\"const\\":true}
+    Received: <array> [false,1]
+    Path:     testSchema#/allOf/0/properties/testItems/contains
+  .testNumber should be <= 0
+    Received: <number> 1
+    Path:     testSchema#/allOf/0/properties/testNumber/maximum
+  .testNumber should be > 999
+    Received: <number> 1
+    Path:     testSchema#/allOf/0/properties/testNumber/exclusiveMinimum
+  .testNumber should be multiple of 5
+    Received: <number> 1
+    Path:     testSchema#/allOf/0/properties/testNumber/multipleOf
+  should have required property 'testRequired'
+    Path:     testSchema#/allOf/0/required
+  .testThen should be equal to constant
+    Expected: <boolean> true
+    Received: <null>
+    Path:     testSchema#/allOf/1/then/properties/testThen/const
+  should match \\"then\\" schema
+    Expected: {\\"type\\":\\"object\\",\\"properties\\":{\\"testThen\\":{\\"const\\":true}}}
+    Received: {\\"testType\\":false,\\"testNotEmpty\\":\\"\\",\\"testEnum\\":false,\\"testConst\\":false,\\"testFormat\\":\\"test\\",\\"testPattern\\":\\"test\\",\\"testItems\\":[false,1],\\"testNumber\\":1,\\"testIf\\":true,\\"testThen\\":null}
+    Path:     testSchema#/allOf/1/if
+  should NOT be valid
+    Expected: {\\"type\\":\\"object\\"}
+    Received: {\\"testType\\":false,\\"testNotEmpty\\":\\"\\",\\"testEnum\\":false,\\"testConst\\":false,\\"testFormat\\":\\"test\\",\\"testPattern\\":\\"test\\",\\"testItems\\":[false,1],\\"testNumber\\":1,\\"testIf\\":true,\\"testThen\\":null}
+    Path:     testSchema#/allOf/2/not
 "
 `;

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -175,30 +175,57 @@ describe('toMatchSchema', () => {
   });
 
   describe('output verbose errors', () => {
-    beforeEach(() => {
-      schema = {
-        type: 'object',
-        properties: {
-          testType: {
-            type: 'string',
-            minLength: 1,
-          },
-          testEnum: {
-            enum: [1, 2],
-          },
-          testConst: {
-            const: true,
-          },
-        },
-      };
+    it('should output an error with only the received input printed', () => {
+      // Null
+      expect(() => expect(null)
+        .not.toMatchSchemaWithOptionsUnderTest({
+          type: 'null',
+        }))
+        .toThrowErrorMatchingSnapshot();
+
+      // Boolean
+      expect(() => expect(true)
+        .not.toMatchSchemaWithOptionsUnderTest({
+          type: 'boolean',
+        }))
+        .toThrowErrorMatchingSnapshot();
+
+      // Number
+      expect(() => expect(1)
+        .not.toMatchSchemaWithOptionsUnderTest({
+          type: 'number',
+        }))
+        .toThrowErrorMatchingSnapshot();
+
+      // String
+      expect(() => expect('this is valid but expect().not.toMatchSchema has been used')
+        .not.toMatchSchemaWithOptionsUnderTest({
+          type: 'string',
+        }))
+        .toThrowErrorMatchingSnapshot();
+
+      // Object
+      expect(() => expect({})
+        .not.toMatchSchemaWithOptionsUnderTest({
+          type: 'object',
+        }))
+        .toThrowErrorMatchingSnapshot();
+
+      // Array
+      expect(() => expect(['this is valid but expect().not.toMatchSchema has been used'])
+        .not.toMatchSchemaWithOptionsUnderTest({
+          minItems: 1,
+        }))
+        .toThrowErrorMatchingSnapshot();
     });
 
-    it('should output an error with only the received input data printed', () => {
-      expect(() => expect({
-        testType: 'this is valid but expect().not.toMatchSchema has been used',
-        testEnum: 1,
-        testConst: true,
-      }).not.toMatchSchemaWithOptionsUnderTest(schema))
+    it('should display schema $id in the schema path', () => {
+      expect(() => expect({}).toMatchSchema({
+        $id: 'testSchema',
+        allOf: [{
+          type: 'string',
+        }],
+      }))
         .toThrowErrorMatchingSnapshot();
     });
 
@@ -216,7 +243,6 @@ describe('toMatchSchema', () => {
         testElse: undefined,
         testThen: null,
       }).toMatchSchemaWithOptionsUnderTest({
-        $id: 'testSchema',
         $schema: 'http://json-schema.org/draft-07/schema#',
         allOf: [
           {

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -366,7 +366,7 @@ describe('toMatchSchema', () => {
 
     it('ensure verbose readme example is correct', () => {
       const testSchema = {
-        $id: 'testSchema',
+        $id: 'testVerboseReadmeSchema',
         type: 'object',
         properties: {
           name: {
@@ -389,13 +389,13 @@ describe('toMatchSchema', () => {
       }).toThrowErrorMatchingInlineSnapshot(`
 "expect(received).toMatchSchema(schema)
 
-Received:
+received
   .name should be string
     Received: <null>
-    Path: testSchema#/properties/name/type
+    Path:     testVerboseReadmeSchema#/properties/name/type
   .dob should match format \\"date\\"
     Received: <string> 02-29-2000
-    Path: testSchema#/properties/dob/format
+    Path:     testVerboseReadmeSchema#/properties/dob/format
 "
 `);
     });

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -220,10 +220,17 @@ describe('toMatchSchema', () => {
     });
 
     it('should display schema $id in the schema path', () => {
-      expect(() => expect({}).toMatchSchema({
+      expect(() => expect({
+        test: '123',
+      }).toMatchSchemaWithOptionsUnderTest({
         $id: 'testSchema',
         allOf: [{
-          type: 'string',
+          type: 'object',
+          properties: {
+            test: {
+              type: 'number',
+            },
+          },
         }],
       }))
         .toThrowErrorMatchingSnapshot();
@@ -355,6 +362,42 @@ describe('toMatchSchema', () => {
           },
         ],
       })).toThrowErrorMatchingSnapshot();
+    });
+
+    it('ensure verbose readme example is correct', () => {
+      const testSchema = {
+        $id: 'testSchema',
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          dob: {
+            type: 'string',
+            format: 'date',
+          },
+        },
+      };
+
+      const invalidData = {
+        name: null,
+        dob: '02-29-2000',
+      };
+
+      expect(() => {
+        expect(invalidData).toMatchSchemaWithOptionsUnderTest(testSchema);
+      }).toThrowErrorMatchingInlineSnapshot(`
+"expect(received).toMatchSchema(schema)
+
+Received:
+  .name should be string
+    Received: <null>
+    Path: testSchema#/properties/name/type
+  .dob should match format \\"date\\"
+    Received: <string> 02-29-2000
+    Path: testSchema#/properties/dob/format
+"
+`);
     });
   });
 });

--- a/matchers/toMatchSchema.js
+++ b/matchers/toMatchSchema.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, no-unused-vars, prefer-const, max-len */
 /*
  * Copyright (c) 2017 American Express Travel Related Services Company, Inc.
  *
@@ -15,15 +16,85 @@
 const chalk = require('chalk');
 const { matcherHint } = require('jest-matcher-utils');
 
+// Keywords where the `Expected: ...` output is hidden
+const ERROR_KEYWORDS_HIDE_EXPECTED = [
+  'type',
+  // String
+  'pattern',
+  'format',
+  'minLength',
+  'maxLength',
+  // Number
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  // Object
+  'minProperties',
+  'maxProperties',
+  'required',
+  // Array
+  'minItems',
+  'maxItems',
+];
+
+// Keywords where the `Received: ...` output is shown
+const ERROR_KEYWORDS_SHOW_RECEIVED = [
+  'if',
+  'not',
+];
+
+const isObject = input => Object.prototype.toString.call(input) === '[object Object]';
+
+const formatForPrint = (input, displayType = true) => {
+  // Undefined and null are both a type and a value
+  if (input === undefined || input === null) {
+    return chalk.yellow(`<${input}>`);
+  }
+
+  // Empty string should be explicitly marked
+  if (input === '') {
+    return chalk.yellow('<empty string>');
+  }
+
+  // Array or object are stringified
+  if (Array.isArray(input) || isObject(input)) {
+    return (displayType
+      ? chalk.yellow(Array.isArray(input)
+        ? '<array> '
+        : '<object> ')
+      : '') + JSON.stringify(input);
+  }
+
+  // String, number or boolean always output their type.
+  // This helps distinguish values that might look the same,
+  // e.g. `<number> 1` and `<string> 1`
+  return `${chalk.yellow(`<${typeof input}>`)} ${input}`;
+};
+
 function buildToMatchSchema(ajv) {
+  // eslint-disable-next-line no-underscore-dangle
+  const { verbose } = ajv._opts;
+
   return function toMatchSchema(received, schema, description) {
     const validate = ajv.compile(schema);
     const pass = validate(received);
 
     const message = pass
-      ? () => `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema`
+      ? () => {
+        let messageToPrint = `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema\n\n`;
+
+        if (verbose) {
+          messageToPrint += chalk.red('received\n');
+          messageToPrint += chalk.red(`${formatForPrint(received, false)}\n`);
+        }
+
+        return messageToPrint;
+      }
       : () => {
         let messageToPrint = `${description || 'received'}\n`;
+
         validate.errors.forEach((error) => {
           let line = error.message;
 
@@ -33,8 +104,36 @@ function buildToMatchSchema(ajv) {
             line = `${error.dataPath} ${error.message}`;
           }
 
+          if (verbose && error.schemaPath) {
+            // Only output expected value if it is not already described in the error.message
+            if (!ERROR_KEYWORDS_HIDE_EXPECTED.includes(error.keyword)) {
+              switch (error.keyword) {
+                // Display the then/else schema which triggered the error
+                case 'if':
+                  line += `\n    Expected: ${formatForPrint(error.parentSchema[error.params.failingKeyword], false)}`;
+                  break;
+
+                default:
+                  line += `\n    Expected: ${formatForPrint(error.schema, false)}`;
+                  break;
+              }
+            }
+
+            // Show received value if there is a dataPath
+            if (error.dataPath) {
+              line += `\n    Received: ${formatForPrint(error.data)}`;
+
+              // Otherwise show received output only for specific keywords
+            } else if (ERROR_KEYWORDS_SHOW_RECEIVED.includes(error.keyword)) {
+              line += `\n    Received: ${formatForPrint(error.data, false)}`;
+            }
+
+            line += `\n    Path:     ${validate.schema.$id || ''}${error.schemaPath}`;
+          }
+
           messageToPrint += chalk.red(`  ${line}\n`);
         });
+
         return `${matcherHint('.toMatchSchema', undefined, 'schema')}\n\n${messageToPrint}`;
       };
 

--- a/matchers/toMatchSchema.js
+++ b/matchers/toMatchSchema.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console, no-unused-vars, prefer-const, max-len */
 /*
  * Copyright (c) 2017 American Express Travel Related Services Company, Inc.
  *
@@ -86,8 +85,7 @@ function buildToMatchSchema(ajv) {
         let messageToPrint = `${matcherHint('.not.toMatchSchema', undefined, 'schema')}\n\nExpected value not to match schema\n\n`;
 
         if (verbose) {
-          messageToPrint += chalk.red('received\n');
-          messageToPrint += chalk.red(`${formatForPrint(received, false)}\n`);
+          messageToPrint += chalk.red(`received\n${formatForPrint(received)}\n`);
         }
 
         return messageToPrint;


### PR DESCRIPTION
This is more an RFC to get people's comments and feedback on how the errors detected during `toMatchSchema` can better help the schema development and test writing process. I used a locally linked version of this to write an extensive schema testing suite and it really helped a lot!

I wanted to have a bit more detail to debug and adjust my schemas during development. Since more detail for errors is available via `ajvOptions.verbose` option I decided to use the value of that to output more detailed messages in the `toMatchSchema` matcher:

* `Received: ...` - displays the value (or schema) that was received that generated the error
* `Expected: ...` - displays the value(s) (or schema) that was expected to not have an error
* `Path: ...` - displays the JSON pointer path to the received value (or schema) that generated the error (also appends the schema's `$id` for convenience)

**TODO:**
- [x] initial working proposal for outputting verbose messages
- [x] resolve test coverage not being 100%
- [x] add documentation detailing the `ajvOptions.verbose` flag and how it influences the `jest-json-schema` error output
- [x] add documentation showing examples of using file-based schemas, along with refs (see issue #7 )