### PR TITLE
chore(workflows): add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity."
+          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity."
+          stale-issue-label: "stale-issue"
+          exempt-issue-labels: "enhancement,documentation,good-first-issue,question"
+          stale-pr-label: "stale-pr"
+          exempt-pr-labels: "work-in-progress"
+          days-before-stale: 30
+          days-before-close: -1


### PR DESCRIPTION
This PR does the following:

- Adds stale action v3
- Adds `days-before-close` to `-1` so it doesn't close anything (https://github.com/actions/stale/blob/master/action.yml#L16)
- Adds `exempt-issue-labels` and `exempt-pr-labels`