### PR TITLE
chore(main): remove the deprecated function matchersWithFormats

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index matchersWithFormats should return all the matchers 1`] = `
-Object {
-  "toBeValidSchema": [Function],
-  "toMatchSchema": [Function],
-}
-`;
-
 exports[`index matchersWithOptions should return all the matchers 1`] = `
 Object {
   "toBeValidSchema": [Function],

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -12,26 +12,11 @@
  * the License.
  */
 
-const { matchers, matchersWithFormats, matchersWithOptions } = require('..');
+const { matchers, matchersWithOptions } = require('..');
 
 describe('index', () => {
   it('should export all the matchers from the matchers directory', () => {
     expect(matchers).toMatchSnapshot();
-  });
-
-  describe('matchersWithFormats', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn');
-
-    beforeEach(() => consoleWarnSpy.mockClear());
-
-    it('should return all the matchers', () => {
-      expect(matchersWithFormats()).toMatchSnapshot();
-    });
-
-    it('should warn that the method is deprecated', () => {
-      matchersWithFormats();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-    });
   });
 
   describe('matchersWithOptions', () => {

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -15,8 +15,10 @@
 const ajvKeywords = require('ajv-keywords');
 const chalk = require('chalk');
 const toMatchSchemaUnderTest = require('../..').matchers.toMatchSchema;
-const toMatchSchemaWithFormatsUnderTest = require('../..').matchersWithFormats({
-  bcp47: /^[a-z]{2}-[A-Z]{2}$/,
+const toMatchSchemaWithFormatsUnderTest = require('../..').matchersWithOptions({
+  formats: {
+    bcp47: /^[a-z]{2}-[A-Z]{2}$/,
+  },
 }).toMatchSchema;
 const toMatchSchemaWithOptionsUnderTest = require('../..').matchersWithOptions({
   verbose: true,

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@
  */
 
 const Ajv = require('ajv');
-const chalk = require('chalk');
 const buildToMatchSchema = require('./matchers/toMatchSchema');
 const buildToBeValidSchema = require('./matchers/toBeValidSchema');
 
@@ -35,12 +34,4 @@ function matchersWithOptions(userOptions = {}, extendAjv) {
 }
 
 module.exports.matchers = matchersWithOptions();
-module.exports.matchersWithFormats = (formats = {}) => {
-  // eslint-disable-next-line no-console
-  console.warn(chalk.yellow(
-    'matchersWithFormats has been deprecated and will be removed in the next major version.\n'
-    + 'Please use matchersWithOptions instead.'
-  ));
-  return matchersWithOptions({ unknownFormats: true, formats });
-};
 module.exports.matchersWithOptions = matchersWithOptions;


### PR DESCRIPTION
If #22 is merged and a major release done, this would also be an opportunity to remove the long-deprecated `matchersWithFormats ` 