### PR TITLE
chore(deps): upgrade AJV to vesion 7

### DIFF
--- a/__tests__/matchers/__snapshots__/toBeValidSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toBeValidSchema.spec.js.snap
@@ -18,6 +18,6 @@ exports[`toBeValidSchema fails schemas with invalid properties 1`] = `
 "expect(schema).toBeValidSchema()
 
 schema
-  .properties should be object
+  /properties should be object
 "
 `;

--- a/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
+++ b/__tests__/matchers/__snapshots__/toMatchSchema.spec.js.snap
@@ -4,7 +4,7 @@ exports[`toMatchSchema custom formats bcp47 it does not match 123 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .locale should match format \\"bcp47\\"
+  /locale should match format \\"bcp47\\"
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`toMatchSchema custom formats bcp47 it does not match EN-US 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .locale should match format \\"bcp47\\"
+  /locale should match format \\"bcp47\\"
 "
 `;
 
@@ -20,7 +20,7 @@ exports[`toMatchSchema custom formats bcp47 it does not match en_US 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .locale should match format \\"bcp47\\"
+  /locale should match format \\"bcp47\\"
 "
 `;
 
@@ -28,7 +28,7 @@ exports[`toMatchSchema custom formats bcp47 it does not match en-us 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .locale should match format \\"bcp47\\"
+  /locale should match format \\"bcp47\\"
 "
 `;
 
@@ -36,7 +36,7 @@ exports[`toMatchSchema custom formats bcp47 it does not match enus 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .locale should match format \\"bcp47\\"
+  /locale should match format \\"bcp47\\"
 "
 `;
 
@@ -64,7 +64,7 @@ exports[`toMatchSchema does not crash on circular references 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .hello should be string
+  /hello should be string
 "
 `;
 
@@ -88,7 +88,7 @@ exports[`toMatchSchema fails for wrong type 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .hello should be string
+  /hello should be string
 "
 `;
 
@@ -104,7 +104,7 @@ exports[`toMatchSchema fails when pattern does not match 1`] = `
 "expect(received).toMatchSchema(schema)
 
 received
-  .hello should match pattern \\"[a-z]+\\"
+  /hello should match pattern \\"[a-z]+\\"
 "
 `;
 
@@ -112,7 +112,7 @@ exports[`toMatchSchema includes the description in the error when provided 1`] =
 "expect(received).toMatchSchema(schema)
 
 en-US language pack
-  .hello should be string
+  /hello should be string
 "
 `;
 
@@ -120,7 +120,7 @@ exports[`toMatchSchema output verbose errors should display schema $id in the sc
 "expect(received).toMatchSchema(schema)
 
 received
-  .test should be number
+  /test should be number
     Received: <string> 123
     Path:     testSchema#/allOf/0/properties/test/type
 "
@@ -190,10 +190,12 @@ exports[`toMatchSchema output verbose errors should output error with details pr
 "expect(received).toMatchSchema(schema)
 
 received
-  should NOT have more than 1 properties
+  should NOT have more than 1 items
     Path:     #/allOf/0/maxProperties
-  should NOT have fewer than 999 properties
+  should NOT have fewer than 999 items
     Path:     #/allOf/0/minProperties
+  should have required property 'testRequired'
+    Path:     #/allOf/0/required
   should match pattern \\"^false\\"
     Path:     #/allOf/0/propertyNames/pattern
   property name 'testType' is invalid
@@ -249,64 +251,68 @@ received
   property name 'testThen' is invalid
     Expected: {\\"pattern\\":\\"^false\\"}
     Path:     #/allOf/0/propertyNames
-  .testType should be null
+  /testType should be null
     Received: <boolean> false
     Path:     #/allOf/0/properties/testType/type
-  .testNotEmpty should NOT be shorter than 1 characters
+  /testNotEmpty should NOT have fewer than 1 characters
     Received: <empty string>
     Path:     #/allOf/0/properties/testNotEmpty/minLength
-  .testEnum should be equal to one of the allowed values
+  /testEnum should be equal to one of the allowed values
     Expected: [1,2]
     Received: <boolean> false
     Path:     #/allOf/0/properties/testEnum/enum
-  .testConst should be equal to constant
+  /testConst should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
     Path:     #/allOf/0/properties/testConst/const
-  .testFormat should match format \\"email\\"
+  /testFormat should match format \\"email\\"
     Received: <string> test
     Path:     #/allOf/0/properties/testFormat/format
-  .testPattern should match pattern \\"[0-9]+\\"
+  /testPattern should match pattern \\"[0-9]+\\"
     Received: <string> test
     Path:     #/allOf/0/properties/testPattern/pattern
-  .testItems should NOT have more than 1 items
+  /testItems should NOT have more than 1 items
     Received: <array> [false,1]
     Path:     #/allOf/0/properties/testItems/maxItems
-  .testItems should NOT have fewer than 5 items
+  /testItems should NOT have fewer than 5 items
     Received: <array> [false,1]
     Path:     #/allOf/0/properties/testItems/minItems
-  .testItems[0] should be equal to constant
+  /testItems/0 should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
     Path:     #/allOf/0/properties/testItems/items/const
-  .testItems[1] should be equal to constant
+  /testItems/1 should be equal to constant
     Expected: <boolean> true
     Received: <number> 1
     Path:     #/allOf/0/properties/testItems/items/const
-  .testItems[0] should be equal to constant
+  /testItems/0 should be equal to constant
     Expected: <boolean> true
     Received: <boolean> false
     Path:     #/allOf/0/properties/testItems/contains/const
-  .testItems[1] should be equal to constant
+  /testItems/1 should be equal to constant
     Expected: <boolean> true
     Received: <number> 1
     Path:     #/allOf/0/properties/testItems/contains/const
-  .testItems should contain a valid item
+  /testItems should contain at least 1 valid item(s)
     Expected: {\\"const\\":true}
     Received: <array> [false,1]
     Path:     #/allOf/0/properties/testItems/contains
-  .testNumber should be <= 0
+  /testNumber should be <= 0
     Received: <number> 1
     Path:     #/allOf/0/properties/testNumber/maximum
-  .testNumber should be > 999
+  /testNumber should be >= 999
+    Received: <number> 1
+    Path:     #/allOf/0/properties/testNumber/minimum
+  /testNumber should be < 1
+    Received: <number> 1
+    Path:     #/allOf/0/properties/testNumber/exclusiveMaximum
+  /testNumber should be > 999
     Received: <number> 1
     Path:     #/allOf/0/properties/testNumber/exclusiveMinimum
-  .testNumber should be multiple of 5
+  /testNumber should be multiple of 5
     Received: <number> 1
     Path:     #/allOf/0/properties/testNumber/multipleOf
-  should have required property 'testRequired'
-    Path:     #/allOf/0/required
-  .testThen should be equal to constant
+  /testThen should be equal to constant
     Expected: <boolean> true
     Received: <null>
     Path:     #/allOf/1/then/properties/testThen/const

--- a/__tests__/matchers/toMatchSchema.spec.js
+++ b/__tests__/matchers/toMatchSchema.spec.js
@@ -392,10 +392,10 @@ describe('toMatchSchema', () => {
 "expect(received).toMatchSchema(schema)
 
 received
-  .name should be string
+  /name should be string
     Received: <null>
     Path:     testVerboseReadmeSchema#/properties/name/type
-  .dob should match format \\"date\\"
+  /dob should match format \\"date\\"
     Received: <string> 02-29-2000
     Path:     testVerboseReadmeSchema#/properties/dob/format
 "

--- a/index.js
+++ b/index.js
@@ -12,17 +12,20 @@
  * the License.
  */
 
-const Ajv = require('ajv');
+const Ajv = require('ajv').default;
+const addFormats = require('ajv-formats');
 const buildToMatchSchema = require('./matchers/toMatchSchema');
 const buildToBeValidSchema = require('./matchers/toBeValidSchema');
 
 function matchersWithOptions(userOptions = {}, extendAjv) {
   const defaultOptions = {
     allErrors: true,
+    strict: false,
   };
 
   const options = Object.assign(defaultOptions, userOptions);
   const ajv = new Ajv(options);
+  addFormats(ajv);
   if (typeof extendAjv === 'function') {
     extendAjv(ajv);
   }

--- a/matchers/toMatchSchema.js
+++ b/matchers/toMatchSchema.js
@@ -73,8 +73,7 @@ const formatForPrint = (input, displayType = true) => {
 };
 
 function buildToMatchSchema(ajv) {
-  // eslint-disable-next-line no-underscore-dangle
-  const { verbose } = ajv._opts;
+  const { verbose } = ajv.opts;
 
   return function toMatchSchema(received, schema, description) {
     const validate = ajv.compile(schema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,20 +2303,28 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+      "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.5.1.tgz",
+      "integrity": "sha512-s1RBVF4HZd2UjGkb6t6uWoXjf6o7j7dXPQIL7vprcIT/67bTD6+5ocsU0UKShS2qWxueGDWuGfKHfOxHWrlTQg==",
+      "requires": {
+        "ajv": "^7.0.0"
+      }
+    },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-4.0.0.tgz",
+      "integrity": "sha512-baL4pEYniCF5E/5Cj28f1DmPXGGASQIeCFfntY94vJPtrq0fei3iNt/TP5f2IwEH4opCzcOOvL6hKsi2IHaecg==",
       "dev": true
     },
     "amex-jest-preset": {
@@ -4196,6 +4204,18 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -4217,6 +4237,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "semver": {
@@ -4936,9 +4962,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -4957,7 +4983,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5333,6 +5360,26 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "hard-rejection": {
@@ -8500,9 +8547,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13500,6 +13547,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -14706,6 +14758,24 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -15147,9 +15217,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "author": "Jimmy King <jimmy.king@aexp.com> (https://github.com/10xLaCroixDrinker)",
   "license": "Apache-2.0",
   "dependencies": {
-    "ajv": "^6.10.2",
+    "ajv": "^7.0.3",
+    "ajv-formats": "^1.5.1",
     "chalk": "^4.1.0",
     "jest-matcher-utils": "^26.6.1"
   },
@@ -44,7 +45,7 @@
     "@semantic-release/github": "^7.1.1",
     "@semantic-release/npm": "^7.0.6",
     "@semantic-release/release-notes-generator": "^9.0.1",
-    "ajv-keywords": "^3.4.1",
+    "ajv-keywords": "^4.0.0",
     "amex-jest-preset": "^6.1.0",
     "eslint": "^5.2.0",
     "eslint-config-amex": "^9.0.0",


### PR DESCRIPTION
This probably requires some iteration but I think it's a good base to start a discussion how upgrading to AJV 7 would look like for `jest-json-schmema`.

- #23 should be merged before this one as it removes code that'd be modified in this PR
- [Strict mode](https://github.com/ajv-validator/ajv/blob/v7.0.2/docs/strict-mode.md) is disabled. It might make sense to enable it by default (the user could always override it) but it'd require more changes from users when upgrading. Thoughts?
- Related to the above, currently the test suite causes a lot of warnings when run in strict mode. These could be fixed independent of the decision above (actually independent of upgrading to AJV 7). Should they?
-  I've included `ajv-formats` by default to approximate the experience of AJV 6. Maybe this should be left to the user?