### PR TITLE
docs(README): Update broken AJV options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ expect.extend(matchers);
 Or if you want it available for all test files then set it up the same way in a
 [test framework script file](http://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string)
 
-You can pass [Ajv options](http://epoberezkin.github.io/ajv/#options) using
+You can pass [Ajv options](https://ajv.js.org/options.html) using
 `matchersWithOptions` and passing it your options object. The only option passed
 by default is `allErrors: true`.
 


### PR DESCRIPTION
## Description
The README link to AJV options is broken due to the AJV repository changing ownership

## Types of Changes
I have updated the link to point to the new AJV documentation website

## Checklist:
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Jest-Json-Schema/?
No impact
