### PR TITLE
feat(index): add AjvClass option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ expect.extend(matchersWithOptions({ formats }, (ajv) => {
 }));
 ```
 
+You can also customize the `Ajv` class with the `AjvClass` option:
+
+```js
+import Ajv2020 from 'ajv/dist/2020'
+import { matchersWithOptions } from 'jest-json-schema';
+
+expect.extend(matchersWithOptions({ AjvClass: Ajv2020 }));
+```
+
 ### Verbose errors
 
 Ajv supports a verbose option flag which enables more information about individual

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -29,5 +29,15 @@ describe('index', () => {
       matchersWithOptions({}, callback);
       expect(callback).toHaveBeenCalled();
     });
+
+    it('accepts a custom Ajv class', () => {
+      const FakeAjvClass = jest.fn().mockImplementation(() => ({
+        opts: { code: { formats: {} } },
+        addFormat: jest.fn(),
+        addKeyword: jest.fn(),
+      }));
+      matchersWithOptions({ AjvClass: FakeAjvClass });
+      expect(FakeAjvClass).toHaveBeenCalled();
+    });
   });
 });

--- a/index.js
+++ b/index.js
@@ -21,10 +21,12 @@ function matchersWithOptions(userOptions = {}, extendAjv) {
   const defaultOptions = {
     allErrors: true,
     strict: false,
+    AjvClass: Ajv,
   };
 
   const options = Object.assign(defaultOptions, userOptions);
-  const ajv = new Ajv(options);
+  const { AjvClass, ...ajvOptions } = options;
+  const ajv = new AjvClass(ajvOptions);
   addFormats(ajv);
   if (typeof extendAjv === 'function') {
     extendAjv(ajv);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows to customize the Ajv class used for validation, which is
required to use draft-2020-12 schemas.

See https://ajv.js.org/json-schema.html#draft-2020-12

## Motivation and Context

We needed this to use the [lottie schema](https://lottiefiles.github.io/lottie-docs/schema/) with this plugin.

## How Has This Been Tested?

I added a test in this repository and used my fork in our own tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Jest-Json-Schema/?

Ability to validate draft-2020-12 schemas.
